### PR TITLE
ci: workflow de GitHub Actions para tests en PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Los archivos de environment estan gitignored y se generan desde .env.
+      # En CI se usan valores placeholder: los tests mockean el HTTP, asi que
+      # las claves no necesitan ser reales, solo deben existir para resolver
+      # el import '@environments/environment'.
+      - name: Generate environment files
+        run: npm run set:envs
+        env:
+          API_URL_TMDB: https://api.example.com
+          API_KEY_TMDB: ci-dummy-key
+          API_URL_IMAGE_TMDB: https://image.example.com
+          API_URL_IPGEOLOCATION: https://geo.example.com
+          API_KEY_IPGEOLOCATION: ci-dummy-key
+
       - name: Test
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Qué hace

Añade el pipeline de **CI** en `.github/workflows/ci.yml`. En cada `pull_request` y `push` hacia `develop` y `main` ejecuta los tests unitarios del proyecto.

## Detalles

- **Pasos:** `npm ci` → `npm test` (jest, single run).
- **Node 24** (alineado con el entorno local), con **caché de npm**.
- Acciones oficiales **fijadas por SHA**:
  - `actions/checkout` # v4.3.1
  - `actions/setup-node` # v4.4.0
- `permissions: contents: read` (privilegio mínimo).
- `concurrency` con `cancel-in-progress` para cancelar runs obsoletos del mismo PR.

## Alcance

Solo **CI de tests**. El build/deploy lo sigue gestionando Vercel automáticamente al mergear a `main`. No se incluye `lint` porque el proyecto aún no tiene script de lint.