### PR TITLE
chore: eliminar dependencia residual de Netlify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@angular/build": "^20.3.5",
         "@angular/cli": "^20.3.5",
         "@angular/compiler-cli": "^20.3.4",
-        "@netlify/angular-runtime": "^2.3.1",
         "@testing-library/angular": "^18.1.0",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/user-event": "^14.6.1",
@@ -4648,58 +4647,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@netlify/angular-runtime": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@netlify/angular-runtime/-/angular-runtime-2.3.1.tgz",
-      "integrity": "sha512-lcY7GVO+P9GEXUeBEAw/+gaCEF+M/SNkupzzPctNAiUa7iVfjuvy/b/+ZVIc7wfcq5/BENOsc+8ciwbPu1WNqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fs-extra": "^11.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=18.13.0"
-      }
-    },
-    "node_modules/@netlify/angular-runtime/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/@netlify/angular-runtime/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@netlify/angular-runtime/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@ngx-translate/core": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@angular/build": "^20.3.5",
     "@angular/cli": "^20.3.5",
     "@angular/compiler-cli": "^20.3.4",
-    "@netlify/angular-runtime": "^2.3.1",
     "@testing-library/angular": "^18.1.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## Qué hace

Elimina la dependencia `@netlify/angular-runtime` de `package.json` y `package-lock.json`.

## Por qué

Quedó del primer deploy de la app en Netlify. El despliegue actual lo gestiona **Vercel** automáticamente al mergear a `main`. No hay uso en código ni configuración:

- Sin `netlify.toml` ni carpeta `.netlify`.
- Sin referencias en `angular.json` ni en el código (verificado con grep).

`npm uninstall` eliminó 4 paquetes; el árbol de dependencias queda coherente (`npm ls` sin errores).

## Validación

El CI ejecutará los tests sobre este PR.