### PR TITLE
ci: añadir paso de lint al pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    name: Test
+    name: Lint & Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,6 +29,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # El lint es analisis estatico y no necesita los environments, asi que
+      # se ejecuta antes para fallar rapido ante errores de estilo.
+      - name: Lint
+        run: npm run lint
 
       # Los archivos de environment estan gitignored y se generan desde .env.
       # En CI se usan valores placeholder: los tests mockean el HTTP, asi que


### PR DESCRIPTION
## Qué hace

Añade el paso **`npm run lint`** al workflow de CI (`.github/workflows/ci.yml`).

## Detalles

- Se ejecuta tras `npm ci` y **antes** de generar los environments y correr los tests, para **fallar rápido** ante errores de estilo (el lint es análisis estático y no necesita los environments).
- El job pasa a llamarse **"Lint & Test"**.

## Validación

El propio CI de este PR ejecutará lint + tests, confirmando que el paso queda bien integrado.